### PR TITLE
Ajout de lien data.gouv.fr

### DIFF
--- a/src/choices/config.cljs
+++ b/src/choices/config.cljs
@@ -151,6 +151,6 @@ Un document est « dénaturé » ou « vidé » de son sens s'il ne contient
     :done true}
 
    {:name "oui"
-    :text "Vous devez publier votre document en Open data sur une plateforme dédiée."
+    :text "Vous devez publier votre document en Open data sur une plateforme dédiée. Rendez-vous sur https://www.data.gouv.fr/fr/."
     :done true}])
 


### PR DESCRIPTION
Romain souhaite qu'un lien renvoie de manière plus claire à data.gouv.fr. Je l'ai donc ajouté à la fin de la réponse générale qui oblige à publier les données sur une plateforme dédiée.